### PR TITLE
Drop standardrb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,11 @@ env:
   GIT_BRANCH: ${{ github.ref }}
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Ruby 2.7
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-
   build:
-    needs: [linting]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', 'head']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,6 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true
 
-      - name: Standard
-        run: |
-          gem install standardrb
-          bundle exec standardrb
   build:
     needs: [linting]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
+        ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Standard
         run: |
+          gem install standardrb
           bundle exec standardrb
   build:
     needs: [linting]

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'faraday', '~> 1.0'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'simplecov', '~> 0.19.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gemspec
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+
 gemspec
+
+gem 'faraday', '~> 1.0'
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.0'
+gem 'simplecov', '~> 0.19.0'
+gem 'multipart-parser', '~> 0.1.1'
+gem 'webmock', '~> 3.4'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,3 @@
 
 source 'https://rubygems.org'
 gemspec
-
-group :development do
-  gem "standard"
-end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/faraday-my_adapter.gemspec
+++ b/faraday-my_adapter.gemspec
@@ -21,4 +21,10 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
+
+  # This range would desirable. If that's not possible (e.g. the adapter uses a
+  # new feature like the new streaming API), then a simple ~> 2.5 would
+  # suffice, although it might make it harder for users to use the adapter in
+  # legacy applications.
+  spec.add_dependency "faraday", [">= 1.10", "< 3"]
 end

--- a/faraday-my_adapter.gemspec
+++ b/faraday-my_adapter.gemspec
@@ -21,14 +21,4 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'faraday', '~> 1.0'
-
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.19.0'
-
-  spec.add_development_dependency 'multipart-parser', '~> 0.1.1'
-  spec.add_development_dependency 'webmock', '~> 3.4'
 end

--- a/faraday-my_adapter.gemspec
+++ b/faraday-my_adapter.gemspec
@@ -1,34 +1,34 @@
 # frozen_string_literal: true
 
-require_relative "lib/faraday/my_adapter/version"
+require_relative 'lib/faraday/my_adapter/version'
 
 Gem::Specification.new do |spec|
-  spec.name = "faraday-my_adapter"
+  spec.name = 'faraday-my_adapter'
   spec.version = Faraday::MyAdapter::VERSION
-  spec.authors = ["Your Name"]
-  spec.email = ["your_name@gmail.com"]
+  spec.authors = ['Your Name']
+  spec.email = ['your_name@gmail.com']
 
-  spec.summary = "Faraday adapter for MyAdapter"
-  spec.description = "Faraday adapter for MyAdapter"
-  spec.homepage = "https://github.com/lostisland/faraday-my_adapter"
-  spec.license = "MIT"
+  spec.summary = 'Faraday adapter for MyAdapter'
+  spec.description = 'Faraday adapter for MyAdapter'
+  spec.homepage = 'https://github.com/lostisland/faraday-my_adapter'
+  spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/lostisland/faraday-my_adapter"
-  spec.metadata["changelog_uri"] = "https://github.com/lostisland/faraday-my_adapter"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-my_adapter'
+  spec.metadata['changelog_uri'] = 'https://github.com/lostisland/faraday-my_adapter'
 
-  spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
-  spec.require_paths = ["lib"]
+  spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "faraday", "~> 1.0"
+  spec.add_development_dependency 'faraday', '~> 1.0'
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "simplecov", "~> 0.19.0"
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'simplecov', '~> 0.19.0'
 
-  spec.add_development_dependency "multipart-parser", "~> 0.1.1"
-  spec.add_development_dependency "webmock", "~> 3.4"
+  spec.add_development_dependency 'multipart-parser', '~> 0.1.1'
+  spec.add_development_dependency 'webmock', '~> 3.4'
 end

--- a/lib/faraday/adapter/my_adapter.rb
+++ b/lib/faraday/adapter/my_adapter.rb
@@ -50,11 +50,11 @@ module Faraday
           end
         end
 
-      # NOTE: An adapter `call` MUST return the `env.response`. If `save_response` is the last line in your `call`
-      # method implementation, it will automatically return the response for you.
-      # Otherwise, you'll need to manually do so. You can do this with any (not both) of the following lines:
-      # * @app.call(env)
-      # * env.response
+        # NOTE: An adapter `call` MUST return the `env.response`. If `save_response` is the last line in your `call`
+        # method implementation, it will automatically return the response for you.
+        # Otherwise, you'll need to manually do so. You can do this with any (not both) of the following lines:
+        # * @app.call(env)
+        # * env.response
       # Finally, it's good practice to rescue client-specific exceptions (e.g. Timeout, ConnectionFailed, etc...)
       # and re-raise them as Faraday Errors. Check `Faraday::Error` for a list of all errors.
       rescue MyAdapterTimeout => e

--- a/lib/faraday/adapter/my_adapter.rb
+++ b/lib/faraday/adapter/my_adapter.rb
@@ -53,11 +53,13 @@ module Faraday
         # NOTE: An adapter `call` MUST return the `env.response`. If `save_response` is the last line in your `call`
         # method implementation, it will automatically return the response for you.
         # Otherwise, you'll need to manually do so. You can do this with any (not both) of the following lines:
-        # * @app.call(env)
-        # * env.response
-      # Finally, it's good practice to rescue client-specific exceptions (e.g. Timeout, ConnectionFailed, etc...)
-      # and re-raise them as Faraday Errors. Check `Faraday::Error` for a list of all errors.
+
+        # @app.call(env)
+        # env.response
       rescue MyAdapterTimeout => e
+        # Finally, it's good practice to rescue client-specific exceptions (e.g. Timeout, ConnectionFailed, etc...)
+        # and re-raise them as Faraday Errors. Check `Faraday::Error` for a list of all errors.
+        #
         # Most errors allow you to provide the original exception and optionally (if available) the response, to
         # make them available outside of the middleware stack.
         raise Faraday::TimeoutError, e

--- a/lib/faraday/my_adapter.rb
+++ b/lib/faraday/my_adapter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "adapter/my_adapter"
-require_relative "my_adapter/version"
+require_relative 'adapter/my_adapter'
+require_relative 'my_adapter/version'
 
 module Faraday
   module MyAdapter

--- a/lib/faraday/my_adapter/version.rb
+++ b/lib/faraday/my_adapter/version.rb
@@ -2,6 +2,6 @@
 
 module Faraday
   module MyAdapter
-    VERSION = "0.1.0"
+    VERSION = '0.1.0'
   end
 end

--- a/spec/faraday/adapter/my_adapter_spec.rb
+++ b/spec/faraday/adapter/my_adapter_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Faraday::Adapter::MyAdapter do
   # only the ones you know you can support.
   # TODO: provide the full list of available features!
   features :request_body_on_query_methods,
-    :reason_phrase_parse,
-    :compression,
-    :streaming,
-    :trace_method
+           :reason_phrase_parse,
+           :compression,
+           :streaming,
+           :trace_method
 
   # Runs the tests provide by Faraday, according to the features specified above.
-  it_behaves_like "an adapter"
+  it_behaves_like 'an adapter'
 
   # You can then add any other test specific to this adapter here...
 end

--- a/spec/faraday/my_adapter_spec.rb
+++ b/spec/faraday/my_adapter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::MyAdapter do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Faraday::MyAdapter::VERSION).to be_a(String)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "faraday"
-require "faraday/my_adapter"
+require 'faraday'
+require 'faraday/my_adapter'
 # This is the magic bit. It requires a tests suite from the Faraday gem that you can run against your adapter
-require "faraday_specs_setup"
+require 'faraday_specs_setup'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
This PR removes standardrb from the template.

It also updates the GitHub Workflow a little bit.

In addition, I have deactivated Actions on this repository: the .github/workflows/ci.yml file given is for the benefit of template users, not for this repository.