### PR TITLE
CI: Extend Ruby build matrix, action/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', 'head']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -26,5 +26,4 @@ jobs:
           bundler-cache: true
 
       - name: Test
-        run: |
-          bundle exec rake
+        run: bundle exec rake


### PR DESCRIPTION
This PR extends the CI matrix (perhaps we should keep only non-EOL'd Ruby versions in here).

And, it updates the GitHub Actions for checkout.